### PR TITLE
Auto-detect workflow language

### DIFF
--- a/repo2rocrate/__init__.py
+++ b/repo2rocrate/__init__.py
@@ -12,6 +12,18 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+from importlib import import_module
 from .version import VERSION
 
 __version__ = VERSION
+LANG_NAMES = ["nextflow", "snakemake", "galaxy"]
+LANG_MODULES = {_: import_module(f".{_}", __name__) for _ in LANG_NAMES}
+
+
+def find_workflow(root_dir):
+    for name, module in LANG_MODULES.items():
+        try:
+            return name, module.find_workflow(root_dir)
+        except RuntimeError:
+            pass
+    raise RuntimeError(f"Workflow file not found in {root_dir}")

--- a/repo2rocrate/galaxy.py
+++ b/repo2rocrate/galaxy.py
@@ -126,8 +126,9 @@ class GalaxyCrateBuilder(CrateBuilder):
         return suite
 
 
-def make_crate(root, repo_url=None, version=None, lang_version=None,
+def make_crate(root, workflow=None, repo_url=None, version=None, lang_version=None,
                license=None, ci_workflow=None, diagram=None):
     builder = GalaxyCrateBuilder(root, repo_url=repo_url)
-    wf_source = find_workflow(root)
-    return builder.build(wf_source, version=version, lang_version=lang_version, license=license, ci_workflow=ci_workflow, diagram=diagram)
+    if not workflow:
+        workflow = find_workflow(root)
+    return builder.build(workflow, version=version, lang_version=lang_version, license=license, ci_workflow=ci_workflow, diagram=diagram)

--- a/repo2rocrate/nextflow.py
+++ b/repo2rocrate/nextflow.py
@@ -63,8 +63,9 @@ class NextflowCrateBuilder(CrateBuilder):
         return "nextflow"
 
 
-def make_crate(root, repo_url=None, version=None, lang_version=None,
+def make_crate(root, workflow=None, repo_url=None, version=None, lang_version=None,
                license=None, ci_workflow=None, diagram=None):
     builder = NextflowCrateBuilder(root, repo_url=repo_url)
-    wf_source = find_workflow(root)
-    return builder.build(wf_source, version=version, lang_version=lang_version, license=license, ci_workflow=ci_workflow, diagram=diagram)
+    if not workflow:
+        workflow = find_workflow(root)
+    return builder.build(workflow, version=version, lang_version=lang_version, license=license, ci_workflow=ci_workflow, diagram=diagram)

--- a/repo2rocrate/snakemake.py
+++ b/repo2rocrate/snakemake.py
@@ -35,9 +35,7 @@ def find_workflow(root_dir):
     for p in candidates:
         if p.is_file():
             return p
-    raise RuntimeError(
-        f"workflow definition (one of: {', '.join(candidates)}) not found"
-    )
+    raise RuntimeError(f"workflow definition (one of: {', '.join(map(str, candidates))}) not found")
 
 
 def parse_workflow(workflow_path):

--- a/repo2rocrate/snakemake.py
+++ b/repo2rocrate/snakemake.py
@@ -74,8 +74,9 @@ class SnakemakeCrateBuilder(CrateBuilder):
         return "snakemake"
 
 
-def make_crate(root, repo_url=None, version=None, lang_version=None,
+def make_crate(root, workflow=None, repo_url=None, version=None, lang_version=None,
                license=None, ci_workflow=None, diagram=None):
     builder = SnakemakeCrateBuilder(root, repo_url=repo_url)
-    wf_source = find_workflow(root)
-    return builder.build(wf_source, version=version, lang_version=lang_version, license=license, ci_workflow=ci_workflow, diagram=diagram)
+    if not workflow:
+        workflow = find_workflow(root)
+    return builder.build(workflow, version=version, lang_version=lang_version, license=license, ci_workflow=ci_workflow, diagram=diagram)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -70,6 +70,7 @@ def test_default(data_dir, tmpdir, monkeypatch, to_zip):
 def test_options(data_dir, tmpdir):
     repo_name = "fair-crcc-send-data"
     root = data_dir / repo_name
+    wf_path = root / "pyproject.toml"
     crate_dir = tmpdir / f"{repo_name}-crate"
     repo_url = f"https://github.com/crs4/{repo_name}"
     version = "3.14"
@@ -81,6 +82,7 @@ def test_options(data_dir, tmpdir):
     result = runner.invoke(cli, [
         "-r", str(root),
         "-l", "snakemake",
+        "-w", str(wf_path),
         "-o", str(crate_dir),
         "--repo-url", f"https://github.com/crs4/{repo_name}",
         "--version", version,
@@ -93,6 +95,7 @@ def test_options(data_dir, tmpdir):
     assert crate_dir.is_dir()
     crate = ROCrate(crate_dir)
     workflow = crate.mainEntity
+    assert workflow.id == wf_path.name
     assert workflow["name"] == repo_name
     assert workflow["version"] == version
     image = crate.get(diagram)

--- a/test/test_galaxy.py
+++ b/test/test_galaxy.py
@@ -12,11 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from repo2rocrate.galaxy import make_crate
+import pytest
+from repo2rocrate.galaxy import find_workflow, make_crate
 
 
 GALAXY_ID = "https://w3id.org/workflowhub/workflow-ro-crate#galaxy"
 PLANEMO_ID = "https://w3id.org/ro/terms/test#PlanemoEngine"
+
+
+@pytest.mark.filterwarnings("ignore")
+def test_find_workflow(tmpdir):
+    root = tmpdir / "galaxy-repo"
+    root.mkdir()
+    with pytest.raises(RuntimeError):
+        find_workflow(root)
+    wf_path = root / "foo.ga"
+    with open(wf_path, "wt"):
+        pass
+    assert find_workflow(root) == wf_path
+    new_wf_path = root / "main.ga"
+    with open(new_wf_path, "wt"):
+        pass
+    assert find_workflow(root) == new_wf_path
 
 
 def test_parallel_accession_download(data_dir):

--- a/test/test_galaxy.py
+++ b/test/test_galaxy.py
@@ -27,12 +27,10 @@ def test_find_workflow(tmpdir):
     with pytest.raises(RuntimeError):
         find_workflow(root)
     wf_path = root / "foo.ga"
-    with open(wf_path, "wt"):
-        pass
+    wf_path.touch()
     assert find_workflow(root) == wf_path
     new_wf_path = root / "main.ga"
-    with open(new_wf_path, "wt"):
-        pass
+    new_wf_path.touch()
     assert find_workflow(root) == new_wf_path
 
 

--- a/test/test_nextflow.py
+++ b/test/test_nextflow.py
@@ -12,10 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from repo2rocrate.nextflow import make_crate
+import pytest
+from repo2rocrate.nextflow import find_workflow, make_crate
 
 
 NEXTFLOW_ID = "https://w3id.org/workflowhub/workflow-ro-crate#nextflow"
+
+
+def test_find_workflow(tmpdir):
+    root = tmpdir / "nextflow-repo"
+    with pytest.raises(RuntimeError):
+        find_workflow(root)
+    root.mkdir()
+    wf_path = root / "main.nf"
+    with open(wf_path, "wt"):
+        pass
+    assert find_workflow(root) == wf_path
 
 
 def test_nf_core_foobar(data_dir):

--- a/test/test_nextflow.py
+++ b/test/test_nextflow.py
@@ -21,12 +21,11 @@ NEXTFLOW_ID = "https://w3id.org/workflowhub/workflow-ro-crate#nextflow"
 
 def test_find_workflow(tmpdir):
     root = tmpdir / "nextflow-repo"
+    root.mkdir()
     with pytest.raises(RuntimeError):
         find_workflow(root)
-    root.mkdir()
     wf_path = root / "main.nf"
-    with open(wf_path, "wt"):
-        pass
+    wf_path.touch()
     assert find_workflow(root) == wf_path
 
 

--- a/test/test_snakemake.py
+++ b/test/test_snakemake.py
@@ -28,8 +28,7 @@ def test_find_workflow(tmpdir):
     with pytest.raises(RuntimeError):
         find_workflow(root)
     wf_path = workflow_dir / "Snakefile"
-    with open(wf_path, "wt"):
-        pass
+    wf_path.touch()
     assert find_workflow(root) == wf_path
     new_wf_path = root / "Snakefile"
     shutil.move(wf_path, new_wf_path)

--- a/test/test_snakemake.py
+++ b/test/test_snakemake.py
@@ -12,10 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from repo2rocrate.snakemake import make_crate
+import shutil
+
+import pytest
+from repo2rocrate.snakemake import find_workflow, make_crate
 
 
 SNAKEMAKE_ID = "https://w3id.org/workflowhub/workflow-ro-crate#snakemake"
+
+
+def test_find_workflow(tmpdir):
+    root = tmpdir / "snakemake-repo"
+    workflow_dir = root / "workflow"
+    workflow_dir.mkdir(parents=True)
+    with pytest.raises(RuntimeError):
+        find_workflow(root)
+    wf_path = workflow_dir / "Snakefile"
+    with open(wf_path, "wt"):
+        pass
+    assert find_workflow(root) == wf_path
+    new_wf_path = root / "Snakefile"
+    shutil.move(wf_path, new_wf_path)
+    assert find_workflow(root) == new_wf_path
 
 
 def test_fair_crcc_send_data(data_dir):

--- a/test/test_top_level.py
+++ b/test/test_top_level.py
@@ -1,0 +1,33 @@
+# Copyright 2022 CRS4.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from repo2rocrate import find_workflow
+
+
+def test_find_workflow(tmpdir):
+    root = tmpdir / "repo"
+    root.mkdir()
+    with pytest.raises(RuntimeError):
+        find_workflow(root)
+    cases = [
+        ("nextflow", "main.nf"),
+        ("snakemake", "Snakefile"),
+        ("galaxy", "foo.ga")
+    ]
+    for lang, wf_name in cases:
+        wf_path = root / wf_name
+        wf_path.touch()
+        assert find_workflow(root) == (lang, wf_path)
+        wf_path.unlink()


### PR DESCRIPTION
Adds a top-level `find_workflow` function to find the workflow and detect the repo flavor ("nextflow", "snakemake", "galaxy") at the same time. In the CLI, the new default for `--lang` is to auto-detect: this means that `repo2rocrate`, if the repo has one of the known layouts, should do the right thing when the workflow language is not specified.

Also adds an option to override the workflow path (the default is to auto-detect, as before).