### PR TITLE
Add CLI option to print version

### DIFF
--- a/repo2rocrate/cli.py
+++ b/repo2rocrate/cli.py
@@ -24,19 +24,19 @@ from . import find_workflow, LANG_MODULES
 @click.option('-w', '--workflow', type=click.Path(path_type=Path), help="workflow file (default: auto-detect)")
 @click.option("-o", "--output", type=click.Path(path_type=Path), help="output directory or zip file. The default is the repository root itself, in which case only the metadata file is written")
 @click.option("--repo-url", help="workflow repository URL")
-@click.option("--version", help="workflow version")
+@click.option("--wf-version", help="workflow version")
 @click.option("--lang-version", help="workflow language version")
 @click.option("--license", help="license URL")
 @click.option("--ci-workflow", help="filename (basename) of the GitHub Actions workflow that runs the tests for the workflow")
 @click.option("--diagram", help="relative path of the workflow diagram")
-def cli(root, lang, workflow, output, repo_url, version, lang_version, license, ci_workflow, diagram):
+def cli(root, lang, workflow, output, repo_url, wf_version, lang_version, license, ci_workflow, diagram):
     auto_workflow = None
     if not lang:
         lang, auto_workflow = find_workflow(root)
     if not workflow:
         workflow = auto_workflow
     make_crate = LANG_MODULES[lang].make_crate
-    crate = make_crate(root, workflow=workflow, repo_url=repo_url, version=version, lang_version=lang_version, license=license, ci_workflow=ci_workflow, diagram=diagram)
+    crate = make_crate(root, workflow=workflow, repo_url=repo_url, wf_version=wf_version, lang_version=lang_version, license=license, ci_workflow=ci_workflow, diagram=diagram)
     if not output:
         output = root
     try:

--- a/repo2rocrate/cli.py
+++ b/repo2rocrate/cli.py
@@ -15,7 +15,7 @@
 from pathlib import Path
 
 import click
-from . import find_workflow, LANG_MODULES
+from . import find_workflow, LANG_MODULES, __version__
 
 
 @click.command()
@@ -29,7 +29,11 @@ from . import find_workflow, LANG_MODULES
 @click.option("--license", help="license URL")
 @click.option("--ci-workflow", help="filename (basename) of the GitHub Actions workflow that runs the tests for the workflow")
 @click.option("--diagram", help="relative path of the workflow diagram")
-def cli(root, lang, workflow, output, repo_url, wf_version, lang_version, license, ci_workflow, diagram):
+@click.option("--version", help="print version and exit", is_flag=True)
+def cli(root, lang, workflow, output, repo_url, wf_version, lang_version, license, ci_workflow, diagram, version):
+    if version:
+        print(__version__)
+        return
     auto_workflow = None
     if not lang:
         lang, auto_workflow = find_workflow(root)

--- a/repo2rocrate/common.py
+++ b/repo2rocrate/common.py
@@ -37,13 +37,13 @@ class CrateBuilder(metaclass=ABCMeta):
     def lang(self):
         pass
 
-    def build(self, wf_source, version=None, lang_version=None, license=None, ci_workflow=None, diagram=None):
-        workflow = self.add_workflow(wf_source, version=version, lang_version=lang_version, license=license, diagram=diagram)
+    def build(self, wf_source, wf_version=None, lang_version=None, license=None, ci_workflow=None, diagram=None):
+        workflow = self.add_workflow(wf_source, wf_version=wf_version, lang_version=lang_version, license=license, diagram=diagram)
         self.add_test_suite(workflow=workflow, ci_workflow=ci_workflow)
         self.add_data_entities()
         return self.crate
 
-    def add_workflow(self, wf_source, version=None, lang_version=None, license=None, diagram=None):
+    def add_workflow(self, wf_source, wf_version=None, lang_version=None, license=None, diagram=None):
         if not diagram:
             diagram = self.DIAGRAM
         workflow = self.crate.add_workflow(
@@ -51,8 +51,8 @@ class CrateBuilder(metaclass=ABCMeta):
             lang=self.lang, lang_version=lang_version, gen_cwl=False
         )
         workflow["name"] = self.crate.root_dataset["name"] = self.root.name
-        if version:
-            workflow["version"] = version
+        if wf_version:
+            workflow["version"] = wf_version
         # Is there a Python equivalent of https://github.com/licensee/licensee?
         if license:
             self.crate.root_dataset["license"] = license

--- a/repo2rocrate/galaxy.py
+++ b/repo2rocrate/galaxy.py
@@ -103,8 +103,8 @@ class GalaxyCrateBuilder(CrateBuilder):
             creator = self.crate.add(Entity(self.crate, identifier=id_, properties=properties))
             workflow.append_to("creator", creator)
 
-    def add_workflow(self, wf_source, version=None, lang_version=None, license=None, diagram=None):
-        workflow = super().add_workflow(wf_source, version=version, lang_version=lang_version, license=license, diagram=diagram)
+    def add_workflow(self, wf_source, wf_version=None, lang_version=None, license=None, diagram=None):
+        workflow = super().add_workflow(wf_source, wf_version=wf_version, lang_version=lang_version, license=license, diagram=diagram)
         with open(wf_source) as f:
             wf_code = json.load(f)
         if "release" in wf_code:
@@ -126,9 +126,9 @@ class GalaxyCrateBuilder(CrateBuilder):
         return suite
 
 
-def make_crate(root, workflow=None, repo_url=None, version=None, lang_version=None,
+def make_crate(root, workflow=None, repo_url=None, wf_version=None, lang_version=None,
                license=None, ci_workflow=None, diagram=None):
     builder = GalaxyCrateBuilder(root, repo_url=repo_url)
     if not workflow:
         workflow = find_workflow(root)
-    return builder.build(workflow, version=version, lang_version=lang_version, license=license, ci_workflow=ci_workflow, diagram=diagram)
+    return builder.build(workflow, wf_version=wf_version, lang_version=lang_version, license=license, ci_workflow=ci_workflow, diagram=diagram)

--- a/repo2rocrate/nextflow.py
+++ b/repo2rocrate/nextflow.py
@@ -63,9 +63,9 @@ class NextflowCrateBuilder(CrateBuilder):
         return "nextflow"
 
 
-def make_crate(root, workflow=None, repo_url=None, version=None, lang_version=None,
+def make_crate(root, workflow=None, repo_url=None, wf_version=None, lang_version=None,
                license=None, ci_workflow=None, diagram=None):
     builder = NextflowCrateBuilder(root, repo_url=repo_url)
     if not workflow:
         workflow = find_workflow(root)
-    return builder.build(workflow, version=version, lang_version=lang_version, license=license, ci_workflow=ci_workflow, diagram=diagram)
+    return builder.build(workflow, wf_version=wf_version, lang_version=lang_version, license=license, ci_workflow=ci_workflow, diagram=diagram)

--- a/repo2rocrate/snakemake.py
+++ b/repo2rocrate/snakemake.py
@@ -74,9 +74,9 @@ class SnakemakeCrateBuilder(CrateBuilder):
         return "snakemake"
 
 
-def make_crate(root, workflow=None, repo_url=None, version=None, lang_version=None,
+def make_crate(root, workflow=None, repo_url=None, wf_version=None, lang_version=None,
                license=None, ci_workflow=None, diagram=None):
     builder = SnakemakeCrateBuilder(root, repo_url=repo_url)
     if not workflow:
         workflow = find_workflow(root)
-    return builder.build(workflow, version=version, lang_version=lang_version, license=license, ci_workflow=ci_workflow, diagram=diagram)
+    return builder.build(workflow, wf_version=wf_version, lang_version=lang_version, license=license, ci_workflow=ci_workflow, diagram=diagram)

--- a/setup.py
+++ b/setup.py
@@ -22,10 +22,10 @@ THIS_DIR = Path(__file__).absolute().parent
 
 # don't import version.py so pip can run setup before installing dependencies
 def get_version():
-    pattern = r'VERSION\s*=\s*"([^"]+)"'
+    pattern = r'^VERSION\s*=\s*"([^"]+)"'
     module = THIS_DIR / "repo2rocrate" / "version.py"
     code = module.read_text()
-    return re.search(pattern, code).groups()[0]
+    return re.search(pattern, code, re.MULTILINE).groups()[0]
 
 
 setup(

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -73,7 +73,7 @@ def test_options(data_dir, tmpdir):
     wf_path = root / "pyproject.toml"
     crate_dir = tmpdir / f"{repo_name}-crate"
     repo_url = f"https://github.com/crs4/{repo_name}"
-    version = "3.14"
+    wf_version = "3.14"
     lang_version = "9.9.0"
     license = "http://example.org/license"
     ci_workflow = "conventional-prs.yml"
@@ -85,7 +85,7 @@ def test_options(data_dir, tmpdir):
         "-w", str(wf_path),
         "-o", str(crate_dir),
         "--repo-url", f"https://github.com/crs4/{repo_name}",
-        "--version", version,
+        "--wf-version", wf_version,
         "--lang-version", lang_version,
         "--license", license,
         "--ci-workflow", ci_workflow,
@@ -97,7 +97,7 @@ def test_options(data_dir, tmpdir):
     workflow = crate.mainEntity
     assert workflow.id == wf_path.name
     assert workflow["name"] == repo_name
-    assert workflow["version"] == version
+    assert workflow["version"] == wf_version
     image = crate.get(diagram)
     assert image
     assert set(image.type) == {"File", "ImageObject"}

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -15,10 +15,10 @@
 import shutil
 
 import pytest
+import repo2rocrate
 from click.testing import CliRunner
-from repo2rocrate.cli import cli
 from rocrate.rocrate import ROCrate
-
+from repo2rocrate.cli import cli
 
 SNAKEMAKE_ID = "https://w3id.org/workflowhub/workflow-ro-crate#snakemake"
 
@@ -108,3 +108,10 @@ def test_options(data_dir, tmpdir):
     assert workflow["url"] == crate.root_dataset["isBasedOn"] == repo_url
     instance = [_ for _ in crate.get_entities() if _.type == "TestInstance"][0]
     assert instance["resource"] == f"repos/crs4/{repo_name}/actions/workflows/{ci_workflow}"
+
+
+def test_version():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--version"])
+    assert result.exit_code == 0
+    assert result.output.strip() == repo2rocrate.__version__

--- a/test/test_nextflow.py
+++ b/test/test_nextflow.py
@@ -33,18 +33,18 @@ def test_nf_core_foobar(data_dir):
     repo_name = "nf-core-foobar"
     root = data_dir / repo_name
     repo_url = f"https://github.com/crs4/{repo_name}"
-    version = "0.1.0"
+    wf_version = "0.1.0"
     lang_version = "21.10.3"
     license = "MIT"
     ci_workflow = "ci.yml"
     diagram = "docs/images/nf-core-foobar_logo_light.png"
-    crate = make_crate(root, repo_url=repo_url, version=version, lang_version=lang_version, license=license, ci_workflow=ci_workflow, diagram=diagram)
+    crate = make_crate(root, repo_url=repo_url, wf_version=wf_version, lang_version=lang_version, license=license, ci_workflow=ci_workflow, diagram=diagram)
     assert crate.root_dataset["license"] == license
     # workflow
     workflow = crate.mainEntity
     assert workflow.id == "main.nf"
     assert workflow["name"] == repo_name
-    assert workflow["version"] == version
+    assert workflow["version"] == wf_version
     image = crate.get(diagram)
     assert image
     assert set(image.type) == {"File", "ImageObject"}

--- a/test/test_snakemake.py
+++ b/test/test_snakemake.py
@@ -39,17 +39,17 @@ def test_fair_crcc_send_data(data_dir):
     repo_name = "fair-crcc-send-data"
     root = data_dir / repo_name
     repo_url = f"https://github.com/crs4/{repo_name}"
-    version = "0.1"  # made up
+    wf_version = "0.1"  # made up
     lang_version = "6.5.0"
     license = "GPL-3.0"
     ci_workflow = "main.yml"
-    crate = make_crate(root, repo_url=repo_url, version=version, lang_version=lang_version, license=license, ci_workflow=ci_workflow)
+    crate = make_crate(root, repo_url=repo_url, wf_version=wf_version, lang_version=lang_version, license=license, ci_workflow=ci_workflow)
     assert crate.root_dataset["license"] == license
     # workflow
     workflow = crate.mainEntity
     assert workflow.id == "workflow/Snakefile"
     assert workflow["name"] == repo_name
-    assert workflow["version"] == version
+    assert workflow["version"] == wf_version
     image = crate.get("images/rulegraph.svg")
     assert image
     assert set(image.type) == {"File", "ImageObject"}


### PR DESCRIPTION
Adds a CLI option to print the package version and exit. Since `--version` is the most commonly used option name for this, the option to set the workflow version has been renamed to `--wf-version`.