### PR TITLE
Scrape metadata

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 click
 pyyaml
 rocrate
-snakemake

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     ],
     packages=["repo2rocrate"],
     python_requires='>=3.6, <4',
-    install_requires=["click", "pyyaml", "rocrate", "snakemake"],
+    install_requires=["click", "pyyaml", "rocrate"],
     entry_points={
         "console_scripts": ["repo2rocrate=repo2rocrate.cli:cli"],
     },

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -43,6 +43,9 @@ def test_default(data_dir, tmpdir, monkeypatch, to_zip):
     workflow = crate.mainEntity
     assert workflow.id == "workflow/Snakefile"
     assert workflow["name"] == repo_name
+    language = workflow["programmingLanguage"]
+    assert language.id == SNAKEMAKE_ID
+    assert language["version"] == "6.5.0"
     image = crate.get("images/rulegraph.svg")
     assert image
     assert set(image.type) == {"File", "ImageObject"}

--- a/test/test_nextflow.py
+++ b/test/test_nextflow.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 import pytest
-from repo2rocrate.nextflow import find_workflow, make_crate
+from repo2rocrate.nextflow import find_workflow, get_metadata, make_crate
 
 
 NEXTFLOW_ID = "https://w3id.org/workflowhub/workflow-ro-crate#nextflow"
+REPO_NAME = "nf-core-foobar"
 
 
 def test_find_workflow(tmpdir):
@@ -29,26 +30,58 @@ def test_find_workflow(tmpdir):
     assert find_workflow(root) == wf_path
 
 
-def test_nf_core_foobar(data_dir):
-    repo_name = "nf-core-foobar"
-    root = data_dir / repo_name
-    repo_url = f"https://github.com/crs4/{repo_name}"
-    wf_version = "0.1.0"
-    lang_version = "21.10.3"
+def test_get_metadata(tmpdir, data_dir):
+    metadata = get_metadata(data_dir / REPO_NAME / "nextflow.config")
+    assert len(metadata) == 7
+    assert metadata["name"] == "nf-core/foobar"
+    assert metadata["author"] == "Simone Leo"
+    assert metadata["homePage"] == "https://github.com/nf-core/foobar"
+    assert metadata["description"] == "the foobar pipeline"
+    assert metadata["mainScript"] == "main.nf"
+    assert metadata["nextflowVersion"] == "!>=21.10.3"
+    assert metadata["version"] == "0.1.0"
+    config_file_path = tmpdir / "nextflow.config"
+    config_file_path.write_text(
+        "manifest{name='nf-core/foobar'\n"
+        "version='0.1.0'}\n"
+    )
+    metadata = get_metadata(config_file_path)
+    assert metadata["name"] == "nf-core/foobar"
+    assert metadata["version"] == "0.1.0"
+
+
+@pytest.mark.parametrize("defaults", [False, True])
+def test_nf_core_foobar(data_dir, defaults):
+    root = data_dir / REPO_NAME
     license = "MIT"
-    ci_workflow = "ci.yml"
-    diagram = "docs/images/nf-core-foobar_logo_light.png"
-    crate = make_crate(root, repo_url=repo_url, wf_version=wf_version, lang_version=lang_version, license=license, ci_workflow=ci_workflow, diagram=diagram)
+    kwargs = {"license": license}
+    if defaults:
+        repo_url = "https://github.com/nf-core/foobar"
+        wf_version = "0.1.0"
+        lang_version = "!>=21.10.3"
+        ci_workflow = "ci.yml"
+        diagram = None
+        resource = f"repos/nf-core/foobar/actions/workflows/{ci_workflow}"
+    else:
+        repo_url = f"https://github.com/crs4/{REPO_NAME}"
+        wf_version = "0.9.9"
+        lang_version = "21.10.0"
+        ci_workflow = "linting.yml"
+        diagram = "docs/images/nf-core-foobar_logo_light.png"
+        resource = f"repos/crs4/{REPO_NAME}/actions/workflows/{ci_workflow}"
+        kwargs.update(repo_url=repo_url, wf_version=wf_version, lang_version=lang_version, license=license, ci_workflow=ci_workflow, diagram=diagram)
+    crate = make_crate(root, **kwargs)
     assert crate.root_dataset["license"] == license
     # workflow
     workflow = crate.mainEntity
     assert workflow.id == "main.nf"
-    assert workflow["name"] == repo_name
+    assert workflow["name"] == "nf-core/foobar"
     assert workflow["version"] == wf_version
-    image = crate.get(diagram)
-    assert image
-    assert set(image.type) == {"File", "ImageObject"}
-    assert workflow["image"] is image
+    if diagram:
+        image = crate.get(diagram)
+        assert image
+        assert set(image.type) == {"File", "ImageObject"}
+        assert workflow["image"] is image
     language = workflow["programmingLanguage"]
     assert language.id == NEXTFLOW_ID
     assert language["version"] == lang_version
@@ -68,7 +101,7 @@ def test_nf_core_foobar(data_dir):
         instance = instance[0]
     assert instance.type == "TestInstance"
     assert instance["url"] == "https://api.github.com"
-    assert instance["resource"] == f"repos/crs4/{repo_name}/actions/workflows/{ci_workflow}"
+    assert instance["resource"] == resource
     # layout
     expected_data_entities = [
         ("nextflow.config", "File"),

--- a/test/test_nextflow.py
+++ b/test/test_nextflow.py
@@ -77,6 +77,8 @@ def test_nf_core_foobar(data_dir, defaults):
     assert workflow.id == "main.nf"
     assert workflow["name"] == "nf-core/foobar"
     assert workflow["version"] == wf_version
+    assert workflow["creator"] == "Simone Leo"
+    assert workflow["description"] == "the foobar pipeline"
     if diagram:
         image = crate.get(diagram)
         assert image

--- a/test/test_snakemake.py
+++ b/test/test_snakemake.py
@@ -15,7 +15,7 @@
 import shutil
 
 import pytest
-from repo2rocrate.snakemake import find_workflow, make_crate
+from repo2rocrate.snakemake import find_workflow, get_lang_version, make_crate
 
 
 SNAKEMAKE_ID = "https://w3id.org/workflowhub/workflow-ro-crate#snakemake"
@@ -35,6 +35,15 @@ def test_find_workflow(tmpdir):
     assert find_workflow(root) == new_wf_path
 
 
+def test_get_lang_version(tmpdir):
+    v = "0.1.0"
+    wf_path = tmpdir / "Snakefile"
+    for arg_part in f'("{v}")', f"( '{v}')":
+        with open(wf_path, "wt") as f:
+            f.write(f'# comment\nfrom x import y\nmin_version{arg_part}\n')
+        assert get_lang_version(wf_path) == v
+
+
 def test_fair_crcc_send_data(data_dir):
     repo_name = "fair-crcc-send-data"
     root = data_dir / repo_name
@@ -43,7 +52,7 @@ def test_fair_crcc_send_data(data_dir):
     lang_version = "6.5.0"
     license = "GPL-3.0"
     ci_workflow = "main.yml"
-    crate = make_crate(root, repo_url=repo_url, wf_version=wf_version, lang_version=lang_version, license=license, ci_workflow=ci_workflow)
+    crate = make_crate(root, repo_url=repo_url, wf_version=wf_version, license=license, ci_workflow=ci_workflow)
     assert crate.root_dataset["license"] == license
     # workflow
     workflow = crate.mainEntity


### PR DESCRIPTION
Closes #5.

### Note on Snakemake

I've tried to see whether we can get some more metadata with the `snakemake` package. However, the only stable part of the [API](https://snakemake.readthedocs.io/en/v7.0.0/api_reference/snakemake.html) is a top-level function that runs a workflow. Everything else is considered internal. I managed to get something with the following hack:

```python
from snakemake.workflow import Workflow

def parse_workflow(workflow_path):
    wf = Workflow(snakefile=workflow_path, overwrite_configfiles=[])
    try:
        wf.include(workflow_path)
    except Exception:
        pass
    wf.execute(dryrun=True, updated_files=[])
    return wf
```

But even that doesn't seem to completely fill the class attributes. Moreover, it does not work anymore with the latest `snakemake` releases. In the end, I removed it since it was just adding a dependency for nothing.