### PR TITLE
Fix association of data entity descriptions to ids

### DIFF
--- a/repo2rocrate/common.py
+++ b/repo2rocrate/common.py
@@ -127,13 +127,12 @@ class CrateBuilder(metaclass=ABCMeta):
             if self.crate.get(str(relpath)):
                 continue  # existing entity is more specific
             source = self.root / relpath
+            properties = {"description": description} if description else None
             if type_ == "File":
                 if source.is_file():
-                    entity = self.crate.add_file(source, relpath)
+                    self.crate.add_file(source, relpath, properties=properties)
             elif type_ == "Dataset":
                 if source.is_dir():
-                    entity = self.crate.add_dataset(source, relpath)
+                    self.crate.add_dataset(source, relpath, properties=properties)
             else:
                 raise ValueError(f"Unexpected type: {type_!r}")
-            if description:
-                entity["description"] = str(description)

--- a/repo2rocrate/snakemake.py
+++ b/repo2rocrate/snakemake.py
@@ -57,7 +57,7 @@ class SnakemakeCrateBuilder(CrateBuilder):
         ("config", "Dataset", "Configuration folder"),
         ("results", "Dataset", "Output files"),
         ("resources", "Dataset", "Retrieved resources"),
-        ("workflow/rules", "Dataset", "Workflow rule module"),
+        ("workflow/rules", "Dataset", "Workflow rule modules"),
         ("workflow/envs", "Dataset", "Conda environments"),
         ("workflow/scripts", "Dataset", "Scripts folder"),
         ("workflow/notebooks", "Dataset", "Notebooks folder"),

--- a/test/test_galaxy.py
+++ b/test/test_galaxy.py
@@ -114,12 +114,13 @@ def test_make_crate(data_dir, defaults):
         assert engine.type == "SoftwareApplication"
     # layout
     expected_data_entities = [
-        ("CHANGELOG.md", "File"),
-        ("README.md", "File"),
-        (".dockstore.yml", "File"),
-        ("test-data", "Dataset"),
+        ("CHANGELOG.md", "File", "History of changes made to the workflow"),
+        ("README.md", "File", "Workflow documentation"),
+        (".dockstore.yml", "File", "Dockstore metadata file"),
+        ("test-data", "Dataset", "Data files for testing the workflow"),
     ]
-    for relpath, type_ in expected_data_entities:
+    for relpath, type_, desc in expected_data_entities:
         entity = crate.get(relpath)
         assert entity, f"{relpath} not listed in crate metadata"
         assert entity.type == type_
+        assert entity["description"] == desc

--- a/test/test_nextflow.py
+++ b/test/test_nextflow.py
@@ -121,27 +121,28 @@ def test_make_crate(data_dir, defaults):
     assert instance["resource"] == resource
     # layout
     expected_data_entities = [
-        ("nextflow.config", "File"),
-        ("README.md", "File"),
-        ("nextflow_schema.json", "File"),
-        ("CHANGELOG.md", "File"),
-        ("LICENSE", "File"),
-        ("CODE_OF_CONDUCT.md", "File"),
-        ("CITATIONS.md", "File"),
-        ("modules.json", "File"),
-        ("assets", "Dataset"),
-        ("bin", "Dataset"),
-        ("conf", "Dataset"),
-        ("docs", "Dataset"),
-        ("docs/images", "Dataset"),
-        ("lib", "Dataset"),
-        ("modules", "Dataset"),
-        ("modules/local", "Dataset"),
-        ("modules/nf-core", "Dataset"),
-        ("workflows", "Dataset"),
-        ("subworkflows", "Dataset"),
+        ("nextflow.config", "File", "Main Nextflow configuration file"),
+        ("README.md", "File", "Basic pipeline usage information"),
+        ("nextflow_schema.json", "File", "JSON schema for pipeline parameter specification"),
+        ("CHANGELOG.md", "File", "Information on changes made to the pipeline"),
+        ("LICENSE", "File", "The license - should be MIT"),
+        ("CODE_OF_CONDUCT.md", "File", "The nf-core code of conduct"),
+        ("CITATIONS.md", "File", "Citations needed when using the pipeline"),
+        ("modules.json", "File", "Version information for modules from nf-core/modules"),
+        ("assets", "Dataset", "Additional files"),
+        ("bin", "Dataset", "Scripts that must be callable from a pipeline process"),
+        ("conf", "Dataset", "Configuration files"),
+        ("docs", "Dataset", "Markdown files for documenting the pipeline"),
+        ("docs/images", "Dataset", "Images for the documentation files"),
+        ("lib", "Dataset", "Groovy utility functions"),
+        ("modules", "Dataset", "Modules used by the pipeline"),
+        ("modules/local", "Dataset", "Pipeline-specific modules"),
+        ("modules/nf-core", "Dataset", "nf-core modules"),
+        ("workflows", "Dataset", "Main pipeline workflows to be executed in main.nf"),
+        ("subworkflows", "Dataset", "Smaller subworkflows"),
     ]
-    for relpath, type_ in expected_data_entities:
+    for relpath, type_, desc in expected_data_entities:
         entity = crate.get(relpath)
         assert entity, f"{relpath} not listed in crate metadata"
         assert entity.type == type_
+        assert entity["description"] == desc

--- a/test/test_snakemake.py
+++ b/test/test_snakemake.py
@@ -110,15 +110,17 @@ def test_make_crate(data_dir, defaults):
     assert instance["resource"] == f"repos/crs4/{repo_name}/actions/workflows/{ci_workflow}"
     # layout
     expected_data_entities = [
-        ("LICENSE", "File"),
-        ("README.md", "File"),
-        ("config", "Dataset"),
-        (".tests/integration", "Dataset"),
-        ("workflow/rules", "Dataset"),
-        ("workflow/schemas", "Dataset"),
-        ("workflow/scripts", "Dataset"),
+        ("LICENSE", "File", ""),
+        ("README.md", "File", ""),
+        ("config", "Dataset", "Configuration folder"),
+        (".tests/integration", "Dataset", "Integration tests for the workflow"),
+        ("workflow/rules", "Dataset", "Workflow rule modules"),
+        ("workflow/schemas", "Dataset", "Validation files"),
+        ("workflow/scripts", "Dataset", "Scripts folder"),
     ]
-    for relpath, type_ in expected_data_entities:
+    for relpath, type_, desc in expected_data_entities:
         entity = crate.get(relpath)
         assert entity, f"{relpath} not listed in crate metadata"
         assert entity.type == type_
+        if desc:
+            assert entity["description"] == desc


### PR DESCRIPTION
Fixes a problem in `CrateBuilder.add_data_entities` that led to a mismatch between id and description in case one or more of the "recognized" data entities were missing.